### PR TITLE
Fix: background-pattern color

### DIFF
--- a/omni.xml
+++ b/omni.xml
@@ -53,7 +53,7 @@ SOFTWARE.
 	<style name="line-numbers" foreground="weird-gray" background="background"/>
 	<style name="bracket-match" foreground="bone-white" background="background" underline="true"/>
 	<style name="search-match" foreground="selection" background="yellow"/>
-        <style name="background-pattern" background="#5121E"/>
+        <style name="background-pattern" background="#25222E"/>
 
 
 	<style name="def:function" foreground="green"/>


### PR DESCRIPTION
**Changes proposed**
The color for the background-pattern has a missing value. The HEX contains only five digits so no grid was being displayed in gedit. I just changed the HEX to be a color that would work nicely with the theme